### PR TITLE
fix: Move "should run tests" from buildkite to github action

### DIFF
--- a/.github/workflows/trigger_ab_tests.yml
+++ b/.github/workflows/trigger_ab_tests.yml
@@ -9,16 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.forced == false }}
     steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
       - name: "Trigger Buildkite Pipeline"
         run: |
-          curl -X POST https://api.buildkite.com/v2/organizations/firecracker/pipelines/performance-a-b-tests/builds \
-               -H 'Content-Type: application/json' \
-               -H 'Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}' \
-               -d "{
-                    \"commit\": \"HEAD\",
-                    \"branch\": \"$GITHUB_REF_NAME\",
-                    \"env\": {
-                      \"REVISION_A\": \"${{ github.event.before }}\",
-                      \"REVISION_B\": \"${{ github.event.after }}\"
-                    }
-                  }"
+          should_schedule_ab_test=0
+          for f in $(git --no-pager diff --name-only ${{ github.event.before }}..${{ github.event.after }}); do
+            if [[ "$(basename $f)" =~ (\.(rs|toml|lock)|config)$ ]]; then
+              should_schedule_ab_test=1
+            fi
+          done
+          if [[ $should_schedule_ab_test -eq 1 ]]; then
+            curl -X POST https://api.buildkite.com/v2/organizations/firecracker/pipelines/performance-a-b-tests/builds \
+                 -H 'Content-Type: application/json' \
+                 -H 'Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}' \
+                 -d "{
+                      \"commit\": \"HEAD\",
+                      \"branch\": \"$GITHUB_REF_NAME\",
+                      \"env\": {
+                        \"REVISION_A\": \"${{ github.event.before }}\",
+                        \"REVISION_B\": \"${{ github.event.after }}\"
+                      }
+                    }"
+          fi


### PR DESCRIPTION
Our internal check to alarm us if a post-PR A/B-test fails does not fire if a "bailed out" run (e.g. one where we decide not to run A/B-tests because we only modified, say, .md files) happens while a previous A/B-test is still running. This is because it only looks at the most recent buildkite run.

Therefore, move the check whether to run an A/B-test at all from buildkite to the GitHub action that orchestrates the runs, so that "bail outs" happen outside of buildkite.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
